### PR TITLE
docs: fix 'hostname' in examples

### DIFF
--- a/examples/deno.ts
+++ b/examples/deno.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   const client = new Client({
     user: 'user',
     database: 'test',
-    hostname: 'localhost',
+    host: 'localhost',
     port: 5432,
   });
 

--- a/examples/node.ts
+++ b/examples/node.ts
@@ -10,7 +10,7 @@ type MyContext = Context & SessionFlavor<SessionData>;
 async function bootstrap() {
   const client = new Client({
     user: 'postgres',
-    hostname: '127.0.0.1',
+    host: '127.0.0.1',
     database: 'test',
     password: '123456',
     port: 5432


### PR DESCRIPTION
Per https://node-postgres.com/features/connecting#programmatic, it's `host` not `hostname`.